### PR TITLE
#10 TimeZone deprecated

### DIFF
--- a/src/components/SpcChart/AnnotationPlugin.tsx
+++ b/src/components/SpcChart/AnnotationPlugin.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import uPlot from 'uplot';
 
-import { colorManipulator, TimeZone } from '@grafana/data';
+import { colorManipulator } from '@grafana/data';
 import { getTextColorForBackground, UPlotConfigBuilder, useTheme2 } from '@grafana/ui';
 
 const DEFAULT_TIMESERIES_FLAG_COLOR = '#03839e';
@@ -27,7 +27,6 @@ export type AnnotationEntity = Flag | Region;
 export type AnnotationsPluginProps = {
   config: UPlotConfigBuilder;
   annotations: AnnotationEntity[];
-  timeZone: TimeZone;
 };
 
 type ConditionFunc = {
@@ -59,7 +58,7 @@ export function isAnnotationEntityArray(value: any): value is AnnotationEntity[]
   return true;
 }
 
-export const AnnotationsPlugin: React.FC<AnnotationsPluginProps> = ({ annotations, timeZone, config }) => {
+export const AnnotationsPlugin: React.FC<AnnotationsPluginProps> = ({ annotations, config }) => {
   const theme = useTheme2();
 
   const [tooltip, setTooltip] = React.useState<TooltipState | null>(null);

--- a/src/components/SpcChart/AxisPropsReflection.tsx
+++ b/src/components/SpcChart/AxisPropsReflection.tsx
@@ -1,4 +1,4 @@
-import { DecimalCount, GrafanaTheme2, TimeZone } from '@grafana/data';
+import { DecimalCount, GrafanaTheme2 } from '@grafana/data';
 import { AxisPlacement, ScaleDistribution } from '@grafana/ui';
 
 //import {AxisProps} from '@grafana/ui';
@@ -22,9 +22,6 @@ export interface AxisPropsReflection {
   splits?: any; //Axis.Splits;
   values?: any; //Axis.Values;
   isTime?: boolean;
-  //TimeZone is deprecated, because it is reflection of AsixProps, witch also has deprecated zone
-  // eslint-disable-next-line deprecation/deprecation
-  timeZone?: TimeZone;
   color?: any; //uPlot.Axis.Stroke;
   border?: any; //uPlot.Axis.Border;
   decimals?: DecimalCount;

--- a/src/components/SpcChart/AxisPropsReflection.tsx
+++ b/src/components/SpcChart/AxisPropsReflection.tsx
@@ -22,6 +22,8 @@ export interface AxisPropsReflection {
   splits?: any; //Axis.Splits;
   values?: any; //Axis.Values;
   isTime?: boolean;
+  //TimeZone is deprecated, because it is reflection of AsixProps, witch also has deprecated zone
+  // eslint-disable-next-line deprecation/deprecation
   timeZone?: TimeZone;
   color?: any; //uPlot.Axis.Stroke;
   border?: any; //uPlot.Axis.Border;

--- a/src/components/SpcChart/SpcChart.tsx
+++ b/src/components/SpcChart/SpcChart.tsx
@@ -279,7 +279,7 @@ export function SpcChart(props: Props) {
                 timeZone={timeZone}
               />
 
-              {annotations && <AnnotationsPlugin annotations={annotations} config={config} timeZone={timeZone} />}
+              {annotations && <AnnotationsPlugin annotations={annotations} config={config} />}
             </>
           );
         }}


### PR DESCRIPTION
I propose to solve it this way. It is impossible to convert TimeZone into AcisPropsReflection, because AxisProps in the Timeseries component has deprecated TimeZone type. It wasn't necessary in other places, so I deleted it. If it necessary, we can use TimeZoneInfo interface.