### PR TITLE
add standard options section #52

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kensobi-spc-panel",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/ChartPanel.tsx
+++ b/src/components/ChartPanel.tsx
@@ -8,11 +8,19 @@ import { TimeSeriesComponent } from './SpcChart/TimeSeriesComponent';
 import { TimeseriesSettings, defaultTimeseriesSettings } from './SpcChart/types';
 import { calcSpc } from 'data/calcSpc';
 import { useParseOptions } from './options/parseOptions';
+import { Field, FieldConfig, FieldType } from '@grafana/data';
 
 export function ChartPanel(props: ChartPanelProps) {
   const { data, width, height } = props;
   const styles = useStyles2(getStyles);
   const { value: options } = useParseOptions(props.options);
+
+  const getValueFieldIndex = (fields: Field[]): number => (fields[0]?.type !== FieldType.time ? 0 : 1);
+
+  const fields = data.series?.[0]?.fields;
+  const valueFieldIndex = fields ? getValueFieldIndex(fields) : null;
+  const fieldConfig: FieldConfig | undefined =
+    fields && valueFieldIndex !== null ? fields[valueFieldIndex].config : undefined;
 
   const { features, hasTableData, hasCustomTableData } = React.useMemo(() => parseData(data.series), [data.series]);
 
@@ -93,7 +101,12 @@ export function ChartPanel(props: ChartPanelProps) {
         )}
       >
         {selectedFeature && selectedCharacteristic && (
-          <TimeSeriesComponent feature={selectedFeature} characteristic={selectedCharacteristic} settings={settings} />
+          <TimeSeriesComponent
+            feature={selectedFeature}
+            characteristic={selectedCharacteristic}
+            settings={settings}
+            fieldConfig={fieldConfig}
+          />
         )}
       </div>
     </PanelPropsProvider>

--- a/src/components/SpcChart/SpcChart.tsx
+++ b/src/components/SpcChart/SpcChart.tsx
@@ -62,9 +62,9 @@ type Props = {
   lineColor: string;
   showLegend: boolean;
   displayName: string | undefined;
-  decimals: number;
-  max: number | undefined;
-  min: number | undefined;
+  decimals: number | null | undefined;
+  max: number | null | undefined;
+  min: number | null | undefined;
   onSeriesColorChange: (label: string, color: string) => void;
   drawStyle: DrawStyleType;
 };

--- a/src/components/SpcChart/SpcChart.tsx
+++ b/src/components/SpcChart/SpcChart.tsx
@@ -61,13 +61,20 @@ type Props = {
   height: number;
   lineColor: string;
   showLegend: boolean;
+  displayName: string | undefined;
   decimals: number;
+  max: number | undefined;
+  min: number | undefined;
   onSeriesColorChange: (label: string, color: string) => void;
   drawStyle: DrawStyleType;
 };
 
 export function SpcChart(props: Props) {
   const {
+    displayName,
+    max,
+    min,
+    decimals,
     timeField,
     valueField,
     limits,
@@ -80,7 +87,6 @@ export function SpcChart(props: Props) {
     height,
     lineColor,
     showLegend,
-    decimals,
     onSeriesColorChange,
     drawStyle,
   } = props;
@@ -107,6 +113,8 @@ export function SpcChart(props: Props) {
           custom: {
             lineWidth: lineWidth,
           },
+          min: min ?? min,
+          max: max ?? max,
         },
 
         type: FieldType.number,
@@ -177,6 +185,7 @@ export function SpcChart(props: Props) {
 
     const custom: GraphFieldConfig = {
       ...(valField.config?.custom ?? {}),
+      displayName: displayName,
       gradientMode: GraphGradientMode.Opacity,
       lineWidth: lineWidth,
       lineInterpolation: LineInterpolation.Smooth,
@@ -188,8 +197,14 @@ export function SpcChart(props: Props) {
 
     valField.config = {
       thresholds: hasTresholds ? thresholds : undefined,
+      min: min,
+      max: max,
       custom,
-      displayName: valField.labels?.control ? valField.labels?.control + ' sample' : TIMESERIES_SAMPLE_LABEL,
+      displayName: valField.labels?.control
+        ? valField.labels?.control + ' sample'
+        : displayName
+        ? displayName
+        : TIMESERIES_SAMPLE_LABEL,
       color: {
         mode: FieldColorModeId.Fixed,
         fixedColor: lineColor,
@@ -218,18 +233,21 @@ export function SpcChart(props: Props) {
 
     return [df];
   }, [
-    constants,
-    dataFrameName,
-    decimals,
-    fill,
-    limits,
-    lineColor,
-    lineWidth,
-    pointSize,
-    theme,
     timeField,
     valueField,
+    constants,
+    limits,
+    displayName,
+    max,
+    min,
+    lineWidth,
     drawStyle,
+    pointSize,
+    fill,
+    lineColor,
+    dataFrameName,
+    theme,
+    decimals,
   ]);
 
   const tweakAxis = React.useCallback(

--- a/src/components/SpcChart/TimeSeriesComponent.tsx
+++ b/src/components/SpcChart/TimeSeriesComponent.tsx
@@ -1,4 +1,4 @@
-import { GrafanaTheme2 } from '@grafana/data';
+import { FieldConfig, GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 import React from 'react';
 import { SpcChart } from './SpcChart';
@@ -13,9 +13,10 @@ type Props = {
   feature: Feature;
   characteristic: Characteristic;
   settings?: TimeseriesSettings;
+  fieldConfig?: FieldConfig;
 };
 
-export function TimeSeriesComponent({ characteristic, settings }: Props) {
+export function TimeSeriesComponent({ characteristic, settings, fieldConfig }: Props) {
   const styles = useStyles2(getStyles);
 
   const settingsWithDefaults = React.useMemo(() => defaults(settings, defaultTimeseriesSettings), [settings]);
@@ -28,11 +29,11 @@ export function TimeSeriesComponent({ characteristic, settings }: Props) {
   const fill = settingsWithDefaults.fill!;
   const lineColor = settingsWithDefaults.lineColor as string;
   const showLegend = settingsWithDefaults.showLegend;
-  const decimals = settingsWithDefaults.decimals;
+  const decimals = fieldConfig?.decimals;
   const drawStyle = settingsWithDefaults.drawStyle;
-  const max = settingsWithDefaults.max;
-  const min = settingsWithDefaults.min;
-  const displayName = settingsWithDefaults.displayName;
+  const max = fieldConfig?.max;
+  const min = fieldConfig?.min;
+  const displayName = fieldConfig?.displayName;
 
   const limits = React.useMemo(
     () => ({
@@ -122,7 +123,7 @@ export function TimeSeriesComponent({ characteristic, settings }: Props) {
           height={height}
           lineColor={lineColor}
           showLegend={!!showLegend}
-          decimals={decimals ?? 3}
+          decimals={decimals}
           max={max}
           min={min}
           displayName={displayName}

--- a/src/components/SpcChart/TimeSeriesComponent.tsx
+++ b/src/components/SpcChart/TimeSeriesComponent.tsx
@@ -30,6 +30,9 @@ export function TimeSeriesComponent({ characteristic, settings }: Props) {
   const showLegend = settingsWithDefaults.showLegend;
   const decimals = settingsWithDefaults.decimals;
   const drawStyle = settingsWithDefaults.drawStyle;
+  const max = settingsWithDefaults.max;
+  const min = settingsWithDefaults.min;
+  const displayName = settingsWithDefaults.displayName;
 
   const limits = React.useMemo(
     () => ({
@@ -120,6 +123,9 @@ export function TimeSeriesComponent({ characteristic, settings }: Props) {
           lineColor={lineColor}
           showLegend={!!showLegend}
           decimals={decimals ?? 3}
+          max={max}
+          min={min}
+          displayName={displayName}
           onSeriesColorChange={onSeriesColorChange}
           drawStyle={drawStyle ?? 'line'}
         />

--- a/src/components/SpcChart/types.ts
+++ b/src/components/SpcChart/types.ts
@@ -14,6 +14,4 @@ export const defaultTimeseriesSettings: TimeseriesSettings = {
   pointSize: 6,
   lineColor: defaultTimeseriesSettingsColor,
   showLegend: false,
-  decimals: 2,
 };
-

--- a/src/components/options/SimpleParamsEditor.tsx
+++ b/src/components/options/SimpleParamsEditor.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import { TimeSeriesParams, PanelOptions, defaultTimeseriesSettingsColor, DrawStyleType } from 'types';
 import { GrafanaTheme2, StandardEditorProps } from '@grafana/data';
 import { css } from '@emotion/css';
-import { InlineField, InlineSwitch, Input, Select, useStyles2 } from '@grafana/ui';
+import { InlineField, InlineSwitch, Select, useStyles2 } from '@grafana/ui';
 import { InlineColorField } from 'components/InlineColorField';
-import { toNumber } from 'lodash';
 import { selectableZeroToTen, selectableHalfToTen } from './selectableValues';
 
 type Props = StandardEditorProps<TimeSeriesParams, any, PanelOptions>;
@@ -64,22 +63,6 @@ export function SimpleParamsEditor({ value, onChange }: Props) {
             value={value.showLegend}
             onChange={(e) => onChange({ ...value, showLegend: e.currentTarget.checked })}
           />
-          <InlineField label={'Decimals'} className={styles.noMargin}>
-            <Input
-              value={value.decimals ?? ''}
-              onChange={(e) => {
-                let number = toNumber(e.currentTarget.value);
-                const decimals =
-                  e.currentTarget.value === '' || isNaN(number) ? undefined : Math.min(Math.max(number, 0), 6);
-                onChange({ ...value, decimals });
-              }}
-              type="number"
-              min={0}
-              max={6}
-              onFocus={(e) => e.currentTarget.select()}
-              placeholder="Decimal places"
-            />
-          </InlineField>
           <InlineField label={'Graph style'} className={styles.noMargin}>
             <Select
               options={styleOptions}

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import { PanelPlugin } from '@grafana/data';
+import { PanelPlugin, standardEditorsRegistry } from '@grafana/data';
 import { PanelOptions, defaultPanelOptions } from './types';
 import { ChartPanel } from './components/ChartPanel';
 import { LimitsEditor } from './components/options/LimitsEditor';
@@ -8,6 +8,53 @@ import { SpcOptionEditor } from 'components/options/SpcOptionEditor';
 import { parseData } from 'data/parseData';
 
 export const plugin = new PanelPlugin<PanelOptions>(ChartPanel).setPanelOptions((builder) => {
+  builder.addCustomEditor({
+    id: 'timeseriesParams.displayName',
+    path: 'timeseriesParams.displayName',
+    name: 'Display name',
+    description: 'Change the field or series name',
+    editor: standardEditorsRegistry.get('text').editor as any,
+    category: ['Standard options'],
+    settings: {
+      placeholder: 'none',
+      expandTemplateVars: true,
+    },
+  });
+  builder.addCustomEditor({
+    id: 'timeseriesParams.min',
+    path: 'timeseriesParams.min',
+    name: 'Min',
+    description: 'Leave empty to calculate based on all values',
+    editor: standardEditorsRegistry.get('number').editor as any,
+    category: ['Standard options'],
+    settings: {
+      placeholder: 'auto',
+    },
+  });
+  builder.addCustomEditor({
+    id: 'timeseriesParams.max',
+    path: 'timeseriesParams.max',
+    name: 'Max',
+    description: 'Leave empty to calculate based on all values',
+    editor: standardEditorsRegistry.get('number').editor as any,
+    category: ['Standard options'],
+    settings: {
+      placeholder: 'auto',
+    },
+  });
+  builder.addCustomEditor({
+    id: 'timeseriesParams.decimals',
+    path: 'timeseriesParams.decimals',
+    name: 'Decimals',
+    editor: standardEditorsRegistry.get('number').editor as any,
+    category: ['Standard options'],
+    settings: {
+      placeholder: 'auto',
+      min: 0,
+      max: 10,
+      integer: true,
+    },
+  });
   builder.addCustomEditor({
     id: 'spcOptions',
     path: 'spcOptions',

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import { PanelPlugin, standardEditorsRegistry } from '@grafana/data';
+import { FieldConfigProperty, PanelPlugin } from '@grafana/data';
 import { PanelOptions, defaultPanelOptions } from './types';
 import { ChartPanel } from './components/ChartPanel';
 import { LimitsEditor } from './components/options/LimitsEditor';
@@ -7,91 +7,56 @@ import { SimpleParamsEditor } from 'components/options/SimpleParamsEditor';
 import { SpcOptionEditor } from 'components/options/SpcOptionEditor';
 import { parseData } from 'data/parseData';
 
-export const plugin = new PanelPlugin<PanelOptions>(ChartPanel).setPanelOptions((builder) => {
-  builder.addCustomEditor({
-    id: 'timeseriesParams.displayName',
-    path: 'timeseriesParams.displayName',
-    name: 'Display name',
-    description: 'Change the field or series name',
-    editor: standardEditorsRegistry.get('text').editor as any,
-    category: ['Standard options'],
-    settings: {
-      placeholder: 'none',
-      expandTemplateVars: true,
-    },
-  });
-  builder.addCustomEditor({
-    id: 'timeseriesParams.min',
-    path: 'timeseriesParams.min',
-    name: 'Min',
-    description: 'Leave empty to calculate based on all values',
-    editor: standardEditorsRegistry.get('number').editor as any,
-    category: ['Standard options'],
-    settings: {
-      placeholder: 'auto',
-    },
-  });
-  builder.addCustomEditor({
-    id: 'timeseriesParams.max',
-    path: 'timeseriesParams.max',
-    name: 'Max',
-    description: 'Leave empty to calculate based on all values',
-    editor: standardEditorsRegistry.get('number').editor as any,
-    category: ['Standard options'],
-    settings: {
-      placeholder: 'auto',
-    },
-  });
-  builder.addCustomEditor({
-    id: 'timeseriesParams.decimals',
-    path: 'timeseriesParams.decimals',
-    name: 'Decimals',
-    editor: standardEditorsRegistry.get('number').editor as any,
-    category: ['Standard options'],
-    settings: {
-      placeholder: 'auto',
-      min: 0,
-      max: 10,
-      integer: true,
-    },
-  });
-  builder.addCustomEditor({
-    id: 'spcOptions',
-    path: 'spcOptions',
-    name: 'SPC options',
-    description: 'Select options for SPC chart. You can enter a custom sample size value by typing a number.',
-    defaultValue: defaultPanelOptions.spcOptions,
-    editor: SpcOptionEditor,
-    category: ['Chart'],
-    showIf: (_, data) => parseData(data ?? []).hasTableData === false,
-  });
-  builder.addCustomEditor({
-    id: 'constantsConfig',
-    path: 'constantsConfig',
-    name: 'Constants',
-    description: 'Add constants for the chart',
-    defaultValue: defaultPanelOptions.constantsConfig,
-    editor: ConstantsListEditor,
-    category: ['Chart'],
-  });
-  builder.addCustomEditor({
-    id: 'limitConfig',
-    path: 'limitConfig',
-    name: 'Limits',
-    description: 'Upper and lower limits for the chart',
-    defaultValue: defaultPanelOptions.limitConfig,
-    editor: LimitsEditor,
-    category: ['Chart'],
-  });
-  builder.addCustomEditor({
-    id: 'timeseriesParams',
-    path: 'timeseriesParams',
-    name: 'Options',
-    description: 'Timeseries settings',
-    defaultValue: defaultPanelOptions.timeseriesParams,
-    editor: SimpleParamsEditor,
-    category: ['Chart'],
-  });
+export const plugin = new PanelPlugin<PanelOptions>(ChartPanel)
+  .useFieldConfig({
+    disableStandardOptions: [
+      FieldConfigProperty.Unit,
+      FieldConfigProperty.NoValue,
+      FieldConfigProperty.Thresholds,
+      FieldConfigProperty.Mappings,
+      FieldConfigProperty.Links,
+      FieldConfigProperty.Color,
+      FieldConfigProperty.Filterable,
+    ],
+  })
+  .setPanelOptions((builder) => {
+    builder.addCustomEditor({
+      id: 'spcOptions',
+      path: 'spcOptions',
+      name: 'SPC options',
+      description: 'Select options for SPC chart. You can enter a custom sample size value by typing a number.',
+      defaultValue: defaultPanelOptions.spcOptions,
+      editor: SpcOptionEditor,
+      category: ['Chart'],
+      showIf: (_, data) => parseData(data ?? []).hasTableData === false,
+    });
+    builder.addCustomEditor({
+      id: 'constantsConfig',
+      path: 'constantsConfig',
+      name: 'Constants',
+      description: 'Add constants for the chart',
+      defaultValue: defaultPanelOptions.constantsConfig,
+      editor: ConstantsListEditor,
+      category: ['Chart'],
+    });
+    builder.addCustomEditor({
+      id: 'limitConfig',
+      path: 'limitConfig',
+      name: 'Limits',
+      description: 'Upper and lower limits for the chart',
+      defaultValue: defaultPanelOptions.limitConfig,
+      editor: LimitsEditor,
+      category: ['Chart'],
+    });
+    builder.addCustomEditor({
+      id: 'timeseriesParams',
+      path: 'timeseriesParams',
+      name: 'Options',
+      description: 'Timeseries settings',
+      defaultValue: defaultPanelOptions.timeseriesParams,
+      editor: SimpleParamsEditor,
+      category: ['Chart'],
+    });
 
-  return builder;
-});
+    return builder;
+  });

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
   "type": "panel",
-  "name": "SPC Panel",
+  "name": "SPC Chart",
   "id": "kensobi-spc-panel",
   "info": {
     "keywords": ["panel", "spc", "chart", "kensobi"],

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,12 +36,15 @@ export type ConstantsConfig = {
 };
 
 export type TimeSeriesParams = {
+  displayName?: string;
+  min?: number;
+  max?: number;
+  decimals?: number;
   fill?: number;
   lineWidth?: number;
   pointSize?: number;
   lineColor?: string;
   showLegend?: boolean;
-  decimals?: number;
   drawStyle?: DrawStyleType;
 };
 
@@ -59,7 +62,6 @@ export const defaultTimeseriesParams: TimeSeriesParams = {
   pointSize: 6,
   lineColor: defaultTimeseriesSettingsColor,
   showLegend: true,
-  decimals: 2,
   drawStyle: 'line',
 };
 


### PR DESCRIPTION
New “Standard Options” section for customizing the grid area of the SPC panel 